### PR TITLE
fixed basic-ftp version basic-ftp@5.0.5 to basic-ftp@5.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -808,10 +808,11 @@
       ]
     },
     "node_modules/basic-ftp": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
-      "integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.0.tgz",
+      "integrity": "sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       }
@@ -6085,9 +6086,9 @@
       "dev": true
     },
     "basic-ftp": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
-      "integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.0.tgz",
+      "integrity": "sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==",
       "dev": true
     },
     "bignumber.js": {
@@ -7157,7 +7158,7 @@
       "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
       "dev": true,
       "requires": {
-        "basic-ftp": "^5.0.2",
+        "basic-ftp": "^5.2.0",
         "data-uri-to-buffer": "^6.0.2",
         "debug": "^4.3.4"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "hasInstallScript": true,
       "license": "ISC",
       "devDependencies": {
-        "@playwright/test": "1.56.1",
-        "browserstack-node-sdk": "1.40.6"
+        "@playwright/test": "1.58.2",
+        "browserstack-node-sdk": "1.50.3"
       }
     },
     "node_modules/@colors/colors": {
@@ -216,13 +216,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.56.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.56.1.tgz",
-      "integrity": "sha512-vSMYtL/zOcFpvJCW71Q/OEGQb7KYBPAdKh35WNSkaZA75JlAO8ED8UN6GUNTm3drWomcbcqRPFqQbLae8yBTdg==",
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.56.1"
+        "playwright": "1.58.2"
       },
       "bin": {
         "playwright": "cli.js"
@@ -964,9 +964,9 @@
       }
     },
     "node_modules/browserstack-node-sdk": {
-      "version": "1.40.6",
-      "resolved": "https://registry.npmjs.org/browserstack-node-sdk/-/browserstack-node-sdk-1.40.6.tgz",
-      "integrity": "sha512-4Yxf9P+nAKVde34pm9+unN7ZbIWTlRkykHxGB7fQlyXRCl48GS03bPE/x0co5vR4a+JNljNSh5kSYNkr1WqqQQ==",
+      "version": "1.50.3",
+      "resolved": "https://registry.npmjs.org/browserstack-node-sdk/-/browserstack-node-sdk-1.50.3.tgz",
+      "integrity": "sha512-/JMOsuUUILyimaKule93ajl0Px8xt27Z+0IgGBDJWsaCkLYEei21mOd4nkloUl4hcvT1hX4mnDjwOigT3IllOA==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
@@ -997,6 +997,7 @@
         "google-protobuf": "^3.20.1",
         "googleapis": "^126.0.1",
         "got": "^11.8.6",
+        "https-proxy-agent": "^5.0.1",
         "jest-worker": "^28.1.0",
         "js-yaml": "^4.1.0",
         "js-yaml-cloudformation-schema": "^1.0.0",
@@ -1013,7 +1014,7 @@
         "update-notifier": "6.0.2",
         "uuid": "^8.3.2",
         "windows-release": "^5.1.0",
-        "winston": "^3.8.2",
+        "winston": "^3.18.3",
         "winston-transport": "^4.5.0",
         "ws": "^8.17.1",
         "yargs": "^17.5.1",
@@ -3401,10 +3402,11 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -3933,13 +3935,13 @@
       "dev": true
     },
     "node_modules/playwright": {
-      "version": "1.56.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.56.1.tgz",
-      "integrity": "sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==",
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.56.1"
+        "playwright-core": "1.58.2"
       },
       "bin": {
         "playwright": "cli.js"
@@ -3952,9 +3954,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.56.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.56.1.tgz",
-      "integrity": "sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==",
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -4310,10 +4312,11 @@
       }
     },
     "node_modules/rimraf/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -5605,12 +5608,12 @@
       }
     },
     "@playwright/test": {
-      "version": "1.56.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.56.1.tgz",
-      "integrity": "sha512-vSMYtL/zOcFpvJCW71Q/OEGQb7KYBPAdKh35WNSkaZA75JlAO8ED8UN6GUNTm3drWomcbcqRPFqQbLae8yBTdg==",
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
       "dev": true,
       "requires": {
-        "playwright": "1.56.1"
+        "playwright": "1.58.2"
       }
     },
     "@pnpm/config.env-replace": {
@@ -5945,7 +5948,7 @@
       "integrity": "sha512-Q4Q99idbvzmgCTEAAhi32BkOyq8iVI5EwdO0PmBDSGIzzjYNdcFn7Q7k3OzbLy4kLUPXfJtG6fO2RjftXbobBg==",
       "dev": true,
       "requires": {
-        "glob": "^8.0.0",
+        "glob": "8.1.0",
         "graceful-fs": "^4.2.0",
         "lazystream": "^1.0.0",
         "lodash": "^4.17.15",
@@ -6200,9 +6203,9 @@
       }
     },
     "browserstack-node-sdk": {
-      "version": "1.40.6",
-      "resolved": "https://registry.npmjs.org/browserstack-node-sdk/-/browserstack-node-sdk-1.40.6.tgz",
-      "integrity": "sha512-4Yxf9P+nAKVde34pm9+unN7ZbIWTlRkykHxGB7fQlyXRCl48GS03bPE/x0co5vR4a+JNljNSh5kSYNkr1WqqQQ==",
+      "version": "1.50.3",
+      "resolved": "https://registry.npmjs.org/browserstack-node-sdk/-/browserstack-node-sdk-1.50.3.tgz",
+      "integrity": "sha512-/JMOsuUUILyimaKule93ajl0Px8xt27Z+0IgGBDJWsaCkLYEei21mOd4nkloUl4hcvT1hX4mnDjwOigT3IllOA==",
       "dev": true,
       "requires": {
         "@google-cloud/compute": "^4.0.1",
@@ -6232,6 +6235,7 @@
         "google-protobuf": "^3.20.1",
         "googleapis": "^126.0.1",
         "got": "^11.8.6",
+        "https-proxy-agent": "^5.0.1",
         "jest-worker": "^28.1.0",
         "js-yaml": "^4.1.0",
         "js-yaml-cloudformation-schema": "^1.0.0",
@@ -6248,7 +6252,7 @@
         "update-notifier": "6.0.2",
         "uuid": "^8.3.2",
         "windows-release": "^5.1.0",
-        "winston": "^3.8.2",
+        "winston": "^3.18.3",
         "winston-transport": "^4.5.0",
         "ws": "^8.17.1",
         "yargs": "^17.5.1",
@@ -7202,7 +7206,7 @@
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^5.0.1",
+        "minimatch": "5.1.9",
         "once": "^1.3.0"
       }
     },
@@ -8001,9 +8005,9 @@
       "dev": true
     },
     "minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
       "dev": true,
       "requires": {
         "brace-expansion": "^2.0.1"
@@ -8377,19 +8381,19 @@
       "dev": true
     },
     "playwright": {
-      "version": "1.56.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.56.1.tgz",
-      "integrity": "sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==",
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
       "dev": true,
       "requires": {
         "fsevents": "2.3.2",
-        "playwright-core": "1.56.1"
+        "playwright-core": "1.58.2"
       }
     },
     "playwright-core": {
-      "version": "1.56.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.56.1.tgz",
-      "integrity": "sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==",
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
       "dev": true
     },
     "possible-typed-array-names": {
@@ -8540,7 +8544,7 @@
       "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
       "dev": true,
       "requires": {
-        "minimatch": "^5.1.0"
+        "minimatch": "5.1.9"
       }
     },
     "reconnecting-websocket": {
@@ -8623,7 +8627,7 @@
       "integrity": "sha512-Lw7SHMjssciQb/rRz7JyPIy9+bbUshEucPoLRvWqy09vC5zQixl8Uet+Zl+SROBB/JMWHJRdCk1qdxNWHNMvlQ==",
       "dev": true,
       "requires": {
-        "glob": "^7.0.5"
+        "glob": "7.2.3"
       },
       "dependencies": {
         "brace-expansion": {
@@ -8645,15 +8649,15 @@
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
             "inherits": "2",
-            "minimatch": "^3.1.1",
+            "minimatch": "3.1.5",
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
           }
         },
         "minimatch": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+          "version": "3.1.5",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+          "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
           "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "overrides": {
     "qs": "6.14.2",
     "jws": "4.0.1",
-    "tar-fs": "3.1.1"
+    "tar-fs": "3.1.1",
+    "basic-ftp": "^5.2.0"
   },
   "devDependencies": {
     "@playwright/test": "1.56.1",

--- a/package.json
+++ b/package.json
@@ -14,10 +14,19 @@
     "qs": "6.14.2",
     "jws": "4.0.1",
     "tar-fs": "3.1.1",
-    "basic-ftp": "^5.2.0"
+    "basic-ftp": "^5.2.0",
+    "glob@7.2.3": {
+      "minimatch": "3.1.5"
+    },
+    "glob@8.1.0": {
+      "minimatch": "5.1.9"
+    },
+    "readdir-glob": {
+      "minimatch": "5.1.9"
+    }
   },
   "devDependencies": {
-    "@playwright/test": "1.56.1",
-    "browserstack-node-sdk": "1.40.6"
+    "@playwright/test": "1.58.2",
+    "browserstack-node-sdk": "1.50.3"
   }
 }


### PR DESCRIPTION
upgraded vulnerable transitive dependency basic-ftp to a patched version by adding an npm override (basic-ftp: ^5.2.0) and updating the lockfile. This mitigates the path traversal risk in downloadToDir() 