### PR TITLE
APPSEC-449: bump basic-ftp / fast-uri / tmp to fixed versions (3 CVEs)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -409,7 +409,6 @@
       "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@grpc/proto-loader": "^0.8.0",
         "@js-sdsl/ordered-map": "^4.4.2"
@@ -1207,22 +1206,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/bare-events": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
-      "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peerDependencies": {
-        "bare-abort-controller": "*"
-      },
-      "peerDependenciesMeta": {
-        "bare-abort-controller": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/bare-fs": {
       "version": "4.1.6",
       "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.1.6.tgz",
@@ -1309,9 +1292,9 @@
       ]
     },
     "node_modules/basic-ftp": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.0.tgz",
-      "integrity": "sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2558,9 +2541,9 @@
       "dev": true
     },
     "node_modules/fast-uri": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
-      "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
       "dev": true,
       "funding": [
         {
@@ -2571,7 +2554,8 @@
           "type": "opencollective",
           "url": "https://opencollective.com/fastify"
         }
-      ]
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fecha": {
       "version": "4.2.3",
@@ -5551,9 +5535,9 @@
       "license": "MIT"
     },
     "node_modules/tmp": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.6.tgz",
-      "integrity": "sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6409,7 +6393,6 @@
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
       "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@grpc/proto-loader": "^0.8.0",
         "@js-sdsl/ordered-map": "^4.4.2"
@@ -6571,7 +6554,7 @@
       "dev": true,
       "requires": {
         "@percy/sdk-utils": "^1.30.9",
-        "tmp": "^0.2.3"
+        "tmp": "0.2.7"
       }
     },
     "@percy/sdk-utils": {
@@ -6907,7 +6890,7 @@
       "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
+        "fast-uri": "^3.1.3",
         "json-schema-traverse": "^1.0.0",
         "require-from-string": "^2.0.2"
       }
@@ -7041,14 +7024,6 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
-    "bare-events": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
-      "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
-      "dev": true,
-      "optional": true,
-      "requires": {}
-    },
     "bare-fs": {
       "version": "4.1.6",
       "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.1.6.tgz",
@@ -7095,9 +7070,9 @@
       "dev": true
     },
     "basic-ftp": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.0.tgz",
-      "integrity": "sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
       "dev": true
     },
     "bignumber.js": {
@@ -7261,7 +7236,7 @@
         "simple-git": "^3.28.0",
         "stack-trace": "0.0.10",
         "table": "^6.8.1",
-        "tmp": "0.2.6",
+        "tmp": "0.2.7",
         "update-notifier": "6.0.2",
         "uuid": "11.1.1",
         "windows-release": "^5.1.0",
@@ -7984,9 +7959,9 @@
       "dev": true
     },
     "fast-uri": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
-      "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
       "dev": true
     },
     "fecha": {
@@ -8184,7 +8159,7 @@
       "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
       "dev": true,
       "requires": {
-        "basic-ftp": "^5.2.0",
+        "basic-ftp": "^5.3.1",
         "data-uri-to-buffer": "^6.0.2",
         "debug": "^4.3.4"
       }
@@ -10122,9 +10097,9 @@
       "dev": true
     },
     "tmp": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.6.tgz",
-      "integrity": "sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true
     },
     "tr46": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1206,6 +1206,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/bare-events": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
+      "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
+      "dev": true,
+      "optional": true,
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/bare-fs": {
       "version": "4.1.6",
       "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.1.6.tgz",
@@ -3704,7 +3719,6 @@
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -3772,7 +3786,6 @@
       "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -5966,7 +5979,6 @@
       "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -7023,6 +7035,14 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "bare-events": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
+      "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
+      "dev": true,
+      "optional": true,
+      "requires": {}
     },
     "bare-fs": {
       "version": "4.1.6",
@@ -8769,7 +8789,6 @@
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "argparse": "^2.0.1"
       }
@@ -8829,8 +8848,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "json-bigint": {
       "version": "1.0.0",
@@ -10402,7 +10420,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
       "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
-      "peer": true,
       "requires": {}
     },
     "xdg-basedir": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "qs": "6.14.2",
     "jws": "4.0.1",
     "tar-fs": "3.1.1",
-    "basic-ftp": "^5.2.0",
+    "basic-ftp": "^5.3.1",
+    "fast-uri": "^3.1.3",
+    "tmp": "0.2.7",
     "protobufjs": "7.6.4",
     "glob@7.2.3": {
       "minimatch": "3.1.5"


### PR DESCRIPTION
## APPSEC-449 — Playwright sample dependency-CVE bumps

Three transitive (`package-lock.json`) deps bumped to fixed versions via the existing `overrides` block in `package.json`. All verified with `npm audit`.

| Ticket | Package | Change | Advisories cleared |
|---|---|---|---|
| **LTS-2751** | basic-ftp | override `^5.2.0` → `^5.3.1` (→ 5.3.1) | GHSA-rpmf-866q-6p89, GHSA-rp42-5vxx-qpwr, GHSA-chqc-8p9q-pq6q, GHSA-6v7q-wjvx-w8wg (CRLF/FTP cmd injection + DoS, ≤5.3.0) |
| **LTS-3157** | fast-uri | add override `^3.1.3` (→ 3.1.3) | GHSA-q3j6-qgpj-74h6, GHSA-v39h-62p7-jpjc (path traversal + host confusion, ≤3.1.1) |
| **LTS-3397** | tmp | add override `0.2.7` | GHSA-7c78-jf6q-g5cm (path traversal via non-string template, 0.2.6) |

**tmp note:** `npm audit fix` would only "fix" tmp by a **semver-major downgrade of `browserstack-node-sdk` → 1.56.3** (tmp comes through the SDK). The override pins tmp `0.2.7` directly, keeping the SDK at 1.60.1.

### Verification
`npm audit` (advisory DB) no longer flags basic-ftp / fast-uri / tmp after regenerating `package-lock.json` with the overrides.

### ✅ LTS-2752 (lodash) — ALREADY SOLVED, no change in this PR
**Reviewer note:** lodash does **not** need a fix here — it was already remediated by an earlier PR. lodash resolves to **`4.18.1`** (≥ the fixed `4.18.0`) and `npm audit` does not flag it.
- Fixed by **#15** (*LTS-3294: add supply-chain hardened .npmrc*), commit `481a640`, merged **2026-07-07** — the SDK pin in that PR regenerated `package-lock.json` and floated lodash `4.17.21 → 4.18.1` (side effect).
- The LTS-2752 ticket predates that fix (classic scan-time lag), so it reads as open but the code is already patched. **Mark LTS-2752 as already-solved / resolved — nothing to review here.**